### PR TITLE
Fixed ignored :aggregation/init

### DIFF
--- a/src/onyx_local_rt/impl.cljc
+++ b/src/onyx_local_rt/impl.cljc
@@ -113,7 +113,8 @@
 (defn windows->event-map
   [{:keys [onyx.core/windows onyx.core/task] :as event}]
   (let [compiled-windows
-        (map compile-window
+        (map
+         compile-window
          (filter (fn [window] (= (:window/task window) task)) windows))]
     (update-in event [:onyx.core/compiled] assoc :windows compiled-windows)))
 


### PR DESCRIPTION
Tried to be as consistent with onyx core as I could, early checking existence of either :aggregation/init or :window/init and throwing if none supplied.