### PR TITLE
Make batch tasks receive batches of segments

### DIFF
--- a/test/onyx_local_rt/simple/run_job_batch_test.clj
+++ b/test/onyx_local_rt/simple/run_job_batch_test.clj
@@ -1,0 +1,69 @@
+(ns onyx-local-rt.simple.run-job-batch-test
+  (:require [onyx-local-rt.api :as api]
+            [clojure.test :refer [deftest is testing]]))
+
+(def batch-size 5)
+(def num-samples 50)
+(def batch-tracker (atom []))
+(def non-batch-tracker (atom []))
+
+(defn ^:export make-batches [segment]
+  (mapv (fn [n] {:n n}) (range (:n segment))))
+
+(defn ^:export run-a-batch [segments]
+  (swap! batch-tracker conj segments)
+  (mapv (fn [s] {:n2 (:n s)}) segments))
+
+(defn ^:export run-a-non-batch [segment]
+  (swap! non-batch-tracker conj segment)
+  {:n3 (:n2 segment)})
+
+(def job
+  {:workflow [[:in :make-batches]
+              [:make-batches :run-a-batch]
+              [:run-a-batch :run-a-non-batch]
+              [:run-a-non-batch :out]]
+   :catalog [{:onyx/name :in
+              :onyx/type :input
+              :onyx/batch-size 1}
+             {:onyx/name :make-batches
+              :onyx/type :function
+              :onyx/fn ::make-batches
+              :onyx/batch-size 1}
+             {:onyx/name :run-a-batch
+              :onyx/type :function
+              :onyx/fn ::run-a-batch
+              :onyx/batch-size batch-size
+              :onyx/batch-fn? true}
+             {:onyx/name :run-a-non-batch
+              :onyx/type :function
+              :onyx/fn ::run-a-non-batch
+              :onyx/batch-size batch-size
+              ;; no batch-fn? on this one
+              }
+             {:onyx/name :out
+              :onyx/type :output
+              :onyx/batch-size 1}]})
+
+(deftest run-job-batch-test
+  (reset! batch-tracker [])
+  (reset! non-batch-tracker [])
+
+  (let [env-summary (-> (api/init job)
+                        (api/new-segment :in {:n num-samples})
+                        (api/drain)
+                        (api/stop)
+                        (api/env-summary))]
+
+    (testing "workflow executes tasks properly: all inputs are represented in outputs"
+      (is (= (mapv (fn [n] {:n3 n}) (range num-samples))
+             (get-in env-summary [:tasks :out :outputs]))))
+
+    (testing "batch tasks received batches of segments"
+      (is (= (partition batch-size
+                        (mapv (fn [n] {:n n}) (range num-samples)))
+             @batch-tracker)))
+
+    (testing "non-batch tasks received single segments"
+      (is (= (mapv (fn [n] {:n2 n}) (range num-samples))
+             @non-batch-tracker)))))


### PR DESCRIPTION
Background:
My team is hoping to use onyx-local-rt as opposed to regular Onyx because we're running our workflow in a browser/clojurescript environment.  We make several API calls that are much more performant in batch mode, so we'd like to take advantage of `batch-fn?`.

Now, I'm new to this codebase, and to Onyx as a platform, so it's likely that my change is naive.  If this is the case, I'm hoping it will at least spark a bit of conversation about what could be done.

Thanks for making Onyx!